### PR TITLE
Import nti.fakestatsd as perfmetrics.testing.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -17,6 +17,10 @@
   just compile time. See
   https://github.com/zodb/perfmetrics/issues/11.
 
+- Include support for testing applications instrumented with
+  perfmetrics in ``perfmetrics.testing``. This was previously release
+  externally as ``nti.fakestatsd``. See https://github.com/zodb/perfmetrics/issues/9.
+
 2.0 (2013-12-10)
 ================
 

--- a/README.rst
+++ b/README.rst
@@ -15,11 +15,21 @@ software.
 
 Complete documentation is hosted at https://perfmetrics.readthedocs.io
 
+.. image:: https://img.shields.io/pypi/v/perfmetrics.svg
+   :target: https://pypi.org/project/perfmetrics/
+   :alt: Latest release
+
+.. image:: https://img.shields.io/pypi/pyversions/perfmetrics.svg
+   :target: https://pypi.org/project/perfmetrics/
+   :alt: Supported Python versions
+
 .. image:: https://travis-ci.org/zodb/perfmetrics.svg?branch=master
    :target: https://travis-ci.org/zodb/perfmetrics
+   :alt: Travis CI Build Status
 
 .. image:: https://coveralls.io/repos/github/zodb/perfmetrics/badge.svg
    :target: https://coveralls.io/github/zodb/perfmetrics
+   :alt: Code Coverage
 
 .. image:: https://readthedocs.org/projects/perfmetrics/badge/?version=latest
    :target: https://perfmetrics.readthedocs.io/en/latest/?badge=latest

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -4,6 +4,50 @@
 
 .. currentmodule:: perfmetrics
 
+
+Decorators
+==========
+
+.. decorator:: metric
+
+   Notifies Statsd every time the function is called.
+
+   Sends both call counts and timing information.  The name of the metric
+   sent to Statsd is ``<module>.<function name>``.
+
+.. decorator:: metricmethod
+
+   Like ``@metric``, but the name of the Statsd metric is
+   ``<class module>.<class name>.<method name>``.
+
+.. autoclass:: Metric
+.. autoclass:: MetricMod
+
+
+Functions
+=========
+
+.. autofunction:: statsd_client
+.. autofunction:: set_statsd_client
+.. autofunction:: statsd_client_from_uri
+
+
+StatsdClient Methods
+====================
+
+Python code can send custom metrics by first getting the current
+`IStatsdClient` using the `statsd_client()` function.  Note that
+`statsd_client()` returns None if no client has been configured.
+
+.. autointerface:: perfmetrics.interfaces.IStatsdClient
+
+There are three implementations of this interface:
+
+.. autoclass:: perfmetrics.statsd.StatsdClient
+.. autoclass:: perfmetrics.statsd.StatsdClientMod
+.. autoclass:: perfmetrics.statsd.NullStatsdClient
+
+
 Pyramid Integration
 ===================
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -258,21 +258,21 @@ htmlhelp_basename = 'perfmetricsdoc'
 # -- Options for LaTeX output ---------------------------------------------
 
 latex_elements = {
-     # The paper size ('letterpaper' or 'a4paper').
-     #
-     # 'papersize': 'letterpaper',
+    # The paper size ('letterpaper' or 'a4paper').
+    #
+    # 'papersize': 'letterpaper',
 
-     # The font size ('10pt', '11pt' or '12pt').
-     #
-     # 'pointsize': '10pt',
+    # The font size ('10pt', '11pt' or '12pt').
+    #
+    # 'pointsize': '10pt',
 
-     # Additional stuff for the LaTeX preamble.
-     #
-     # 'preamble': '',
+    # Additional stuff for the LaTeX preamble.
+    #
+    # 'preamble': '',
 
-     # Latex figure (float) alignment
-     #
-     # 'figure_align': 'htbp',
+    # Latex figure (float) alignment
+    #
+    # 'figure_align': 'htbp',
 }
 
 # Grouping the document tree into LaTeX files. List of tuples

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -6,55 +6,8 @@
    :caption: Contents:
 
    api
+   testing
    changelog
-
-
-Reference Documentation
-=======================
-
-.. currentmodule:: perfmetrics
-
-Decorators
-----------
-
-.. decorator:: metric
-
-   Notifies Statsd every time the function is called.
-
-   Sends both call counts and timing information.  The name of the metric
-   sent to Statsd is ``<module>.<function name>``.
-
-.. decorator:: metricmethod
-
-   Like ``@metric``, but the name of the Statsd metric is
-   ``<class module>.<class name>.<method name>``.
-
-.. autoclass:: Metric
-.. autoclass:: MetricMod
-
-
-Functions
----------
-
-.. autofunction:: statsd_client
-.. autofunction:: set_statsd_client
-.. autofunction:: statsd_client_from_uri
-
-
-StatsdClient Methods
---------------------
-
-Python code can send custom metrics by first getting the current
-`IStatsdClient` using the `statsd_client()` function.  Note that
-`statsd_client()` returns None if no client has been configured.
-
-.. autointerface:: perfmetrics.interfaces.IStatsdClient
-
-There are three implementations of this interface:
-
-.. autoclass:: perfmetrics.statsd.StatsdClient
-.. autoclass:: perfmetrics.statsd.StatsdClientMod
-.. autoclass:: perfmetrics.statsd.NullStatsdClient
 
 
 ====================

--- a/docs/testing.rst
+++ b/docs/testing.rst
@@ -1,0 +1,87 @@
+=========
+ Testing
+=========
+
+``perfmetrics.testing`` provides a testing client for verifying StatsD
+metrics emitted by perfmetrics in the context of an instrumented
+application.
+
+It's easy to create a new client for use in testing:
+
+.. code-block:: pycon
+
+  >>> from perfmetrics.testing import FakeStatsDClient
+  >>> test_client = FakeStatsDClient()
+
+This client exposes the same public interface as
+`perfmetrics.statsd.StatsdClient`. For example we can increment
+counters, set gauges, etc:
+
+.. code-block:: pycon
+
+  >>> test_client.incr('request_c')
+  >>> test_client.gauge('active_sessions', 320)
+
+Unlike `perfmetrics.statsd.StatsdClient`, `~.FakeStatsDClient` simply
+tracks the statsd packets that would be sent. This information is
+exposed on our ``test_client`` both as the raw statsd packet, and for
+convenience this information is also parsed and exposed as `~.Observation`
+objects. For complete details see `~.FakeStatsDClient` and `~.Observation`.
+
+.. code-block:: pycon
+
+  >>> test_client.packets
+  ['request_c:1|c', 'active_sessions:320|g']
+  >>> test_client.observations
+  [Observation(name='request_c', value='1', kind='c', sampling_rate=None), Observation(name='active_sessions', value='320', kind='g', sampling_rate=None)]
+
+For validating metrics we provide a set of `PyHamcrest
+<https://pypi.org/project/PyHamcrest/>`_ matchers for use in test
+assertions:
+
+.. code-block:: pycon
+
+  >>> from hamcrest import assert_that
+  >>> from hamcrest import contains
+  >>> from perfmetrics.testing.matchers import is_observation
+  >>> from perfmetrics.testing.matchers import is_gauge
+
+We can use both strings and numbers (or any matcher) for the value:
+
+  >>> assert_that(test_client,
+  ...     contains(is_observation('c', 'request_c', '1'),
+  ...              is_gauge('active_sessions', 320)))
+  >>> assert_that(test_client,
+  ...     contains(is_observation('c', 'request_c', '1'),
+  ...              is_gauge('active_sessions', '320')))
+  >>> from hamcrest import is_
+  >>> assert_that(test_client,
+  ...     contains(is_observation('c', 'request_c', '1'),
+  ...              is_gauge('active_sessions', is_('320'))))
+
+If the matching fails, we get a descriptive error:
+
+  >>> assert_that(test_client,
+  ...     contains(is_gauge('request_c', '1'),
+  ...              is_gauge('active_sessions', '320')))
+  Traceback (most recent call last):
+  ...
+  AssertionError:
+  Expected: a sequence containing [(an instance of Observation and (an object with a property 'kind' matching 'g' and an object with a property 'name' matching 'request_c' and an object with a property 'value' matching '1')), (an instance of Observation and (an object with a property 'kind' matching 'g' and an object with a property 'name' matching 'active_sessions' and an object with a property 'value' matching '320'))]
+         but: item 0: was Observation(name='request_c', value='1', kind='c', sampling_rate=None)
+
+
+Reference
+=========
+
+``perfmetrics.testing``
+-----------------------
+.. currentmodule:: perfmetrics.testing
+
+.. automodule:: perfmetrics.testing.client
+   :special-members: __len__, __iter___
+.. automodule:: perfmetrics.testing.observation
+
+``perfmetrics.testing.matchers``
+--------------------------------
+.. automodule:: perfmetrics.testing.matchers

--- a/setup.py
+++ b/setup.py
@@ -161,6 +161,7 @@ setup(
         'docs': [
             'Sphinx >= 2.1.2',
             'repoze.sphinx.autointerface',
+            'pyhamcrest',
             'sphinx_rtd_theme',
         ],
     },

--- a/src/perfmetrics/testing/__init__.py
+++ b/src/perfmetrics/testing/__init__.py
@@ -1,0 +1,23 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+"""
+Support for testing that code is instrumented as expected.
+"""
+from __future__ import print_function, absolute_import, division
+__docformat__ = "restructuredtext en"
+
+__all__ = [
+    'FakeStatsDClient',
+    'Observation',
+    'OBSERVATION_KIND_COUNTER',
+    'OBSERVATION_KIND_GAUGE',
+    'OBSERVATION_KIND_SET',
+    'OBSERVATION_KIND_TIMER',
+]
+
+from .client import FakeStatsDClient
+from .observation import Observation
+from .observation import OBSERVATION_KIND_COUNTER
+from .observation import OBSERVATION_KIND_GAUGE
+from .observation import OBSERVATION_KIND_SET
+from .observation import OBSERVATION_KIND_TIMER

--- a/src/perfmetrics/testing/client.py
+++ b/src/perfmetrics/testing/client.py
@@ -1,0 +1,104 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+from __future__ import print_function, absolute_import, division
+__docformat__ = "restructuredtext en"
+
+
+from perfmetrics.statsd import StatsdClient
+
+from .observation import Observation
+
+
+class _TrackingSocket(object):
+    """
+    Maintain a list of sent packet/address pairs, as well
+    as parsed observations/address pairs.
+    """
+    def __init__(self):
+        self.sent_packets = [] # type: List[Tuple[str, bytes]
+        self.observations = [] # type: List[Tuple[Observation, bytes]
+
+    def clear(self):
+        del self.sent_packets[:]
+        del self.observations[:]
+
+    def sendto(self, data, addr):
+        # The client encoded to bytes
+        assert isinstance(data, bytes)
+        # We always want native strings here, that's what the
+        # user specified when calling the StatsdClient methods.
+        data = data.decode('utf-8') if bytes is not str else data
+        self.sent_packets.append((data, addr,))
+        for m in Observation.make_all(data):
+            self.observations.append((m, addr,))
+
+
+class FakeStatsDClient(StatsdClient):
+    """
+    A mock statsd client that tracks sent statsd metrics in memory
+    rather than pushing them over a socket. This class is a drop
+    in replacement for `perfmetrics.statsd.StatsdClient` that collects statsd
+    packets and `~.Observation` that are sent through the client.
+    """
+
+    def __init__(self, prefix=''):
+        """
+        Create a mock statsd client with the given prefix.
+        """
+        super(FakeStatsDClient, self).__init__(prefix=prefix)
+
+        # Monkey patch the socket to track things in memory instead
+        self.udp_sock.close()
+        self.udp_sock = _TrackingSocket()
+
+    def clear(self):
+        """
+        Clears the statsd metrics that have been collected
+        """
+        self.udp_sock.clear()
+
+    def __len__(self):
+        """
+        The number of metrics sent. This accounts for multi metric packets
+        that may be sent.
+
+        Note that this object will be false if no metrics have been sent.
+        """
+        return len(self.udp_sock.observations)
+
+    def __iter__(self):
+        """
+        Iterates the `Observations <~.Observation>` provided to this statsd
+        client.
+        """
+        for metric, _ in self.udp_sock.observations:
+            yield metric
+    iter_observations = __iter__
+
+    def iter_packets(self):
+        """
+        Iterates the raw statsd packets provided to the statsd client.
+
+        :return: Iterator of native strings.
+        """
+        for data, _ in self.udp_sock.sent_packets:
+            yield data
+
+    @property
+    def observations(self):
+        """
+        A list of `~.Observation` objects collected by this client.
+
+        .. seealso:: `iter_observations`
+        """
+        return [m for m in self]
+
+    @property
+    def packets(self):
+        """
+        A list of raw statsd packets collected by this client.
+
+        .. seealso:: `iter_packets`
+        """
+        return [p for p in self.iter_packets()]

--- a/src/perfmetrics/testing/matchers.py
+++ b/src/perfmetrics/testing/matchers.py
@@ -1,0 +1,147 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+from __future__ import print_function, absolute_import, division
+__docformat__ = "restructuredtext en"
+
+from hamcrest.core.matcher import Matcher
+from hamcrest.core.base_matcher import BaseMatcher
+
+from hamcrest import all_of
+from hamcrest import instance_of
+from hamcrest import is_
+from hamcrest import has_properties
+from hamcrest import none
+
+from .observation import OBSERVATION_KIND_COUNTER as METRIC_COUNTER_KIND
+from .observation import OBSERVATION_KIND_GAUGE as METRIC_GAUGE_KIND
+from .observation import OBSERVATION_KIND_SET as METRIC_SET_KIND
+from .observation import OBSERVATION_KIND_TIMER as METRIC_TIMER_KIND
+
+from .observation import Observation
+
+__all__ = [
+    'is_observation',
+    'is_counter',
+    'is_gauge',
+    'is_set',
+    'is_timer',
+]
+
+_marker = object()
+
+_metric_kind_display_name = {
+    'c': 'counter',
+    'g': 'gauge',
+    'ms': 'timer',
+    's': 'set'
+}
+
+class IsMetric(BaseMatcher):
+
+    def __init__(self, kwargs):
+        matchers = {}
+        for key, value in kwargs.items():
+            if value is None:
+                value = none()
+            elif key == 'sampling_rate':
+                # This one is special, it doesn't get
+                # to be a string, it's kept as a number.
+                value = is_(value)
+            elif not isinstance(value, Matcher):
+                value = str(value)
+            matchers[key] = value
+
+        self._matcher = all_of(
+            instance_of(Observation),
+            has_properties(**matchers)
+        )
+
+    def _matches(self, item):
+        return self._matcher.matches(item)
+
+    def describe_to(self, description):
+        self._matcher.describe_to(description)
+
+    def describe_mismatch(self, item, mismatch_description):
+        mismatch_description.append_text('was ').append_text(repr(item))
+
+def _is_metric(args, kwargs):
+    for arg_ix, name in enumerate((
+            'kind',
+            'name',
+            'value',
+            'sampling_rate'
+    )):
+        if name in kwargs or len(args) <= arg_ix:
+            continue
+        kwargs[name] = args[arg_ix]
+
+    return IsMetric(kwargs)
+
+
+def is_observation(*args, **kwargs):
+    """
+    is_observation(*, kind, name, value, sampling_rate) -> matcher
+
+    A hamcrest matcher that validates the specific parts of a `~.Observation`.
+    All arguments are optional and can be provided by name or position.
+
+    :keyword str kind: A hamcrest matcher or string that matches the kind for this metric
+    :keyword str name: A hamcrest matcher or string that matches the name for this metric
+    :keyword str value: A hamcrest matcher or string that matches the value for this metric
+    :keyword float sampling_rate: A hamcrest matcher or
+        number that matches the sampling rate this metric was collected with
+    """
+    return _is_metric(args, kwargs)
+
+
+def is_counter(*args, **kwargs):
+    """
+    is_counter(*, name, value, sampling_rate) -> matcher
+
+    A hamcrest matcher validating the parts of a counter `~.Observation`.
+
+    .. seealso:: `is_metric`
+    """
+    kwargs['kind'] = METRIC_COUNTER_KIND
+    args = (None,) + args
+    return _is_metric(args, kwargs)
+
+
+def is_gauge(*args, **kwargs):
+    """
+    is_gauge(*, name, value, sampling_rate) -> matcher
+
+    A hamcrest matcher validating the parts of a gauge `~.Observation`
+
+    .. seealso:: `is_metric`
+    """
+    kwargs['kind'] = METRIC_GAUGE_KIND
+    args = (None,) + args
+    return _is_metric(args, kwargs)
+
+
+def is_timer(*args, **kwargs):
+    """
+    is_timer(*, name, value, sampling_rate) -> matcher
+
+    A hamcrest matcher validating the parts of a timer `~.Observation`
+
+    .. seealso:: `is_metric`
+    """
+    kwargs['kind'] = METRIC_TIMER_KIND
+    args = (None,) + args
+    return _is_metric(args, kwargs)
+
+def is_set(*args, **kwargs):
+    """
+    is_set(*, name, value, sampling_rate) -> matcher
+
+    A hamcrest matcher validating the parts of a set `~.Observation`
+
+    .. seealso:: `is_metric`
+    """
+    kwargs['kind'] = METRIC_SET_KIND
+    args = (None,) + args
+    return _is_metric(args, kwargs)

--- a/src/perfmetrics/testing/observation.py
+++ b/src/perfmetrics/testing/observation.py
@@ -1,0 +1,125 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+from __future__ import print_function, absolute_import, division
+__docformat__ = "restructuredtext en"
+
+#: The statsd metric kind for Gauges
+OBSERVATION_KIND_GAUGE = 'g'
+
+#: The statsd metric kind for Counters
+OBSERVATION_KIND_COUNTER = 'c'
+
+#: The statsd metric kind for Sets
+OBSERVATION_KIND_SET = 's'
+
+#: The statsd metric kind for Timers
+OBSERVATION_KIND_TIMER = 'ms'
+
+
+def _parse_sampling_data(data):
+    """
+    Parses sampling rate from the provided packet part *data*.
+
+    Raises a `ValueError` if the packet part is invalid sampling data
+    """
+    if not data.startswith('@'):
+        raise ValueError('Expected "@" in sampling data. %s' % data)
+    return float(data[1:])
+
+
+def _as_metric(metric_data):
+    """
+    Parses a single metric packet, *metric_data*, in to a `Metric`.
+
+    Metrics take the form of <name>:<value>|<type>(|@<sampling_rate>)
+
+    A `ValueError` is raised for invalid data
+    """
+
+    sampling = None
+    name = None
+    value = None
+    kind = None
+    parts = metric_data.split('|')
+    if len(parts) < 2 or len(parts) > 3:
+        raise ValueError('Unexpected metric data %s. Wrong number of parts' % metric_data)
+
+    if len(parts) == 3:
+        sampling_data = parts.pop(-1)
+        sampling = _parse_sampling_data(sampling_data)
+
+    kind = parts[1]
+    name, value = parts[0].split(':')
+
+    return Observation(name, value, kind, sampling_rate=sampling)
+
+
+def _as_metrics(data):
+    """
+    Parses the statsd *data* packet to a _list_ of metrics.
+
+    .. seealso:: https://github.com/etsy/statsd/blob/master/docs/metric_types.md
+    """
+    metrics = []
+
+    # Multi metric packets are seperated by newlines
+    for metric_data in data.split('\n'):
+        metrics.append(_as_metric(metric_data))
+    return metrics
+
+
+class Observation(object):
+    """
+    The representation of a single statsd metric.
+    """
+
+    #: The metric name
+    name = None
+
+    #: The value provided for the metric
+    value = None
+
+    #: The statsd code for the type of metric. e.g. one of the ``METRIC_*_KIND`` constants
+    kind = None
+
+    #: The rate with which this event has been sampled from (optional)
+    sampling_rate = None
+
+    def __init__(self, name, value, kind, sampling_rate=None):
+        self.name = name
+        self.value = value
+        self.sampling_rate = sampling_rate
+        self.kind = kind
+
+    @classmethod
+    def make(cls, packet):
+        """
+        Creates a metric from the provided statsd *packet*.
+
+        :raises ValueError: if *packet* is a multi metric packet or
+                 otherwise invalid.
+        """
+        metrics = cls.make_all(packet)
+        if len(metrics) != 1:
+            raise ValueError('Must supply a single metric packet. %s supplied' % packet)
+        return metrics[0]
+
+    @classmethod
+    def make_all(cls, packet):
+        """
+        Makes a list of metrics from the provided statsd *packet*.
+
+        Like `make` but supports multi metric packets
+        """
+        return _as_metrics(packet)
+
+    def __str__(self):
+        sampling_string = '|@%g' % self.sampling_rate if self.sampling_rate is not None else ''
+        return '%s:%s|%s%s' % (self.name, self.value, self.kind, sampling_string)
+
+    def __repr__(self):
+        return "%s(name=%r, value=%r, kind=%r, sampling_rate=%r)" % (
+            self.__class__.__name__,
+            self.name, self.value, self.kind, self.sampling_rate
+        )

--- a/src/perfmetrics/testing/tests/test_client.py
+++ b/src/perfmetrics/testing/tests/test_client.py
@@ -1,0 +1,104 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+from __future__ import print_function, absolute_import, division
+__docformat__ = "restructuredtext en"
+
+# disable: accessing protected members, too many methods
+# pylint: disable=W0212,R0904
+
+import doctest
+import os
+import unittest
+
+from hamcrest import assert_that
+from hamcrest import contains
+
+from hamcrest import has_length
+from hamcrest import has_properties
+from hamcrest import has_property
+
+
+from .. import FakeStatsDClient as MockStatsDClient
+
+from ..observation import OBSERVATION_KIND_COUNTER as METRIC_COUNTER_KIND
+from ..observation import OBSERVATION_KIND_GAUGE as METRIC_GAUGE_KIND
+from ..observation import OBSERVATION_KIND_SET as METRIC_SET_KIND
+from ..observation import OBSERVATION_KIND_TIMER as METRIC_TIMER_KIND
+
+class TestMockStatsDClient(unittest.TestCase):
+
+    def setUp(self):
+        self.client = MockStatsDClient()
+
+    def test_tracks_metrics(self):
+        self.client.incr('mycounter')
+        self.client.gauge('mygauge', 5)
+        self.client.timing('mytimer', 3003)
+
+        assert_that(self.client, has_length(3))
+
+        counter, gauge, timer = self.client.observations
+
+        assert_that(counter, has_properties('name', 'mycounter',
+                                            'value', '1',
+                                            'kind', METRIC_COUNTER_KIND))
+
+        assert_that(gauge, has_properties('name', 'mygauge',
+                                          'value', '5',
+                                          'kind', METRIC_GAUGE_KIND))
+
+        assert_that(timer, has_properties(
+            'name', 'mytimer',
+            'value', '3003',
+            'kind', METRIC_TIMER_KIND
+        ))
+
+    def test_clear(self):
+        self.client.incr('mycounter')
+        assert_that(self.client, has_length(1))
+
+        self.client.clear()
+        assert_that(self.client, has_length(0))
+
+
+    def test_tracks_multimetrics(self):
+        packet = 'gorets:1|c\nglork:320|ms\ngaugor:333|g\nuniques:765|s'
+        self.client._send(packet)
+
+        assert_that(self.client, has_length(4))
+        assert_that(self.client.packets, contains(packet))
+
+        assert_that(self.client.observations,
+                    contains(has_property('kind', METRIC_COUNTER_KIND),
+                             has_property('kind', METRIC_TIMER_KIND),
+                             has_property('kind', METRIC_GAUGE_KIND),
+                             has_property('kind', METRIC_SET_KIND)))
+
+def test_suite():
+    root = this_dir = os.path.dirname(os.path.abspath(__file__))
+    while not os.path.exists(os.path.join(root, 'setup.py')):
+        prev, root = root, os.path.dirname(root)
+        if root == prev:
+            # Let's avoid infinite loops at root
+            raise AssertionError('could not find my setup.py')
+    docs = os.path.join(root, 'docs')
+    testing_rst = os.path.join(docs, 'testing.rst')
+
+    optionflags = (
+        doctest.NORMALIZE_WHITESPACE
+        | doctest.ELLIPSIS
+        | doctest.IGNORE_EXCEPTION_DETAIL
+    )
+
+    # Can't pass absolute paths to DocFileSuite, needs to be
+    # module relative
+    testing_rst = os.path.relpath(testing_rst, this_dir)
+
+    return unittest.TestSuite((
+        unittest.defaultTestLoader.loadTestsFromName(__name__),
+        doctest.DocFileSuite(
+            testing_rst,
+            optionflags=optionflags
+        ),
+    ))

--- a/src/perfmetrics/testing/tests/test_matchers.py
+++ b/src/perfmetrics/testing/tests/test_matchers.py
@@ -1,0 +1,93 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+from __future__ import print_function, absolute_import, division
+__docformat__ = "restructuredtext en"
+
+
+import unittest
+
+from hamcrest import all_of
+from hamcrest import assert_that
+from hamcrest import contains_string
+from hamcrest import is_not
+from hamcrest import none
+
+from hamcrest.core.string_description import StringDescription
+
+from ..matchers import is_observation as is_metric
+from ..matchers import is_counter
+from ..matchers import is_gauge
+from ..matchers import is_set
+from ..matchers import is_timer
+
+from ..observation import Observation as Metric
+
+
+class TestIsMetric(unittest.TestCase):
+
+    def setUp(self):
+        self.counter = Metric.make('foo:1|c')
+        self.timer = Metric.make('foo:100|ms|@0.1')
+        self.set = Metric.make('foo:bar|s')
+        self.gauge = Metric.make('foo:200|g')
+
+    def test_is_metric(self):
+        assert_that(self.counter, is_metric('c'))
+        assert_that(self.counter, is_metric('c', 'foo'))
+        assert_that(self.counter, is_metric('c', 'foo', '1'))
+        assert_that(self.counter, is_metric('c', 'foo', '1', None))
+
+    def test_non_metric(self):
+        assert_that(object(), is_not(is_metric()))
+
+    def test_is_counter(self):
+        assert_that(self.counter, is_counter())
+
+    def test_is_gauge(self):
+        assert_that(self.gauge, is_gauge())
+
+    def test_is_set(self):
+        assert_that(self.set, is_set())
+
+    def test_is_timer(self):
+        assert_that(self.timer, is_timer())
+
+    def test_bad_kind(self):
+        assert_that(self.counter, is_not(is_timer()))
+
+    def test_bad_name(self):
+        assert_that(self.counter, is_not(is_counter('bar')))
+
+    def test_bad_value(self):
+        assert_that(self.counter, is_not(is_counter('foo', '2')))
+
+    def test_bad_sampling(self):
+        assert_that(self.timer, is_not(is_counter('foo', '100', None)))
+
+    def test_failure_error(self):
+        desc = StringDescription()
+        matcher = is_counter('foo', '1', 0.1)
+        matcher.describe_to(desc)
+        desc = str(desc)
+        assert_that(
+            desc,
+            all_of(
+                contains_string(
+                    "(an instance of Observation and "),
+                contains_string(
+                    "an object with a property 'kind' matching 'c'"),
+                contains_string(
+                    "an object with a property 'name' matching 'foo'"),
+                contains_string(
+                    "an object with a property 'value' matching '1'"),
+                contains_string(
+                    "an object with a property 'sampling_rate' matching <0.1>"
+                )
+            )
+        )
+
+
+    def test_components_can_be_matchers(self):
+        assert_that(self.counter, is_metric('c', 'foo', '1', none()))
+        assert_that(self.timer, is_not(is_metric('ms', 'foo', '100', none())))

--- a/src/perfmetrics/testing/tests/test_observation.py
+++ b/src/perfmetrics/testing/tests/test_observation.py
@@ -1,0 +1,112 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+from __future__ import print_function, absolute_import, division
+__docformat__ = "restructuredtext en"
+
+
+import functools
+
+import unittest
+
+from hamcrest import none
+from hamcrest import assert_that
+from hamcrest import contains
+from hamcrest import is_
+from hamcrest import has_length
+from hamcrest import calling
+from hamcrest import raises
+
+from ..matchers import is_counter
+from ..matchers import is_timer
+from ..matchers import is_gauge
+from ..matchers import is_set
+
+from ..observation import Observation as Metric
+
+
+class TestMetricParsing(unittest.TestCase):
+
+    def test_invalid_packet(self):
+        packet = 'junk'
+        assert_that(calling(functools.partial(Metric.make_all, packet)),
+                    raises(ValueError))
+
+        packet = 'foo|bar|baz|junk'
+        assert_that(calling(functools.partial(Metric.make_all, packet)),
+                    raises(ValueError))
+
+        packet = 'gorets:1|c|0.1'
+        assert_that(calling(functools.partial(Metric.make_all, packet)),
+                    raises(ValueError))
+
+    def test_counter(self):
+        packet = 'gorets:1|c'
+        metric = Metric.make_all(packet)
+
+        assert_that(metric, has_length(1))
+        metric = metric[0]
+
+        assert_that(metric, is_counter('gorets', '1', none()))
+
+    def test_sampled_counter(self):
+        packet = 'gorets:1|c|@0.1'
+        metric = Metric.make_all(packet)
+
+        assert_that(metric, has_length(1))
+        metric = metric[0]
+
+        assert_that(metric, is_counter('gorets', '1', 0.1))
+
+    def test_timer(self):
+        packet = 'glork:320|ms'
+        metric = Metric.make_all(packet)
+
+        assert_that(metric, has_length(1))
+        metric = metric[0]
+
+        assert_that(metric, is_timer('glork', '320'))
+
+
+    def test_set(self):
+        packet = 'glork:3|s'
+        metric = Metric.make_all(packet)
+
+        assert_that(metric, has_length(1))
+        metric = metric[0]
+
+        assert_that(metric, is_set('glork', '3'))
+
+    def test_gauge(self):
+        packet = 'gaugor:+333|g'
+        metric = Metric.make_all(packet)
+
+        assert_that(metric, has_length(1))
+        metric = metric[0]
+
+        assert_that(metric, is_gauge('gaugor', '+333'))
+
+    def test_multi_metric(self):
+        packet = 'gorets:1|c\nglork:320|ms\ngaugor:333|g\nuniques:765|s'
+        metrics = Metric.make_all(packet)
+        assert_that(metrics, contains(is_counter(),
+                                      is_timer(),
+                                      is_gauge(),
+                                      is_set()))
+
+    def test_metric_string(self):
+        metric = Metric.make('gaugor:+333|g')
+        assert_that(str(metric), is_('gaugor:+333|g'))
+
+        packet = 'gorets:1|c|@0.1'
+        metric = Metric.make_all(packet)[0]
+        metric = Metric.make_all(str(metric))[0]
+
+        assert_that(metric, is_counter('gorets', '1', 0.1))
+
+    def test_factory(self):
+        metric = Metric.make('gaugor:+333|g')
+        assert_that(str(metric), is_('gaugor:+333|g'))
+
+        assert_that(calling(functools.partial(Metric.make, 'gaugor:+333|g\ngaugor:+333|g')),
+                    raises(ValueError))


### PR DESCRIPTION
Rename 'Metric' to 'Observation' since we already had a Metric class that did something completely different.

We (@NextThought) hereby officially donate and re-license this code for perfmetrics.

Fixes #9